### PR TITLE
Discard master and slave lingo

### DIFF
--- a/__backup__/construct_graph.py
+++ b/__backup__/construct_graph.py
@@ -205,7 +205,7 @@ if __name__ == "__main__" :
    properties["moisture_list_store"]         =   "MOISTURE_1_DATA_STORE"
    properties["air_temp_list_store"]         =   "MOISTURE_1_AIR_TEMP_LIST_STORE"
    properties["roll_over_list_store"]        =   "MOISTURE_1_ROLL_OVER_LIST_STORE"
-   properties["slave_controller_address"]    =    40
+   properties["subordinate_controller_address"]    =    40
    cf.add_info_node( "MOISTURE_CTR","moisture_1", properties = properties, json_flag= True )
  
    cf.end_header_node("MOISTURE_CONTROLLERS")
@@ -292,7 +292,7 @@ if __name__ == "__main__" :
    properties["modbus_remote"] = "satellite_1"
    properties["m_tag"]          = "read_input_bit"
    properties["parameters"]     = [ "X002"]
-   properties["exec_tag"  ]     = ["get_gpio","master_valve_set_switch"]
+   properties["exec_tag"  ]     = ["get_gpio","main_valve_set_switch"]
    
    cf.add_info_node( "FIFTEEN_SEC_ELEMENT","MASTER_VALVE_SWITCH_SET",properties=properties, json_flag=True)
 
@@ -301,7 +301,7 @@ if __name__ == "__main__" :
    properties["modbus_remote"] = "satellite_1"
    properties["m_tag"]          = "read_input_bit"
    properties["parameters"]     = [ "X003"]
-   properties["exec_tag"  ]     = ["get_gpio","master_valve_reset_switch"]
+   properties["exec_tag"  ]     = ["get_gpio","main_valve_reset_switch"]
    
    cf.add_info_node( "FIFTEEN_SEC_ELEMENT","MASTER_VALVE_SWITCH_RESET",properties=properties, json_flag=True)
 

--- a/__backup__/data_management/configuration.py
+++ b/__backup__/data_management/configuration.py
@@ -36,19 +36,19 @@ irrigation_io["satellite_1"] =  { "remote":  "satellite_1", "type":"CLICK" ,"pin
 irrigation_io["satellite_2"] =  {  "remote": "satellite_2"  , "type":"CLICK" ,"pins_number":22, "unknown":"C201", "clear_duration_counters":"C2","duration_counter":"DS2", "turn_off_bit":"C1"}
 irrigation_io["satellite_3"] =  {  "remote": "satellite_3" , "type":"CLICK" ,"pins_number":22, "unknown":"C201", "clear_duration_counters":"C2","duration_counter":"DS2"  ,"turn_off_bit":"C1"}
 
-master_valve_list = {}
-master_valve_list["satellite_1"] =  { "type":"CLICK", "remote":"satellite_1","master_valve":43, "cleaning_valve":44 } 
+main_valve_list = {}
+main_valve_list["satellite_1"] =  { "type":"CLICK", "remote":"satellite_1","main_valve":43, "cleaning_valve":44 } 
 #
-#  debouncing is handled by slave device
+#  debouncing is handled by subordinate device
 #  latching is enabled or disabled
 #  latching consists of High or Low Latching
 #
 gpio_bit_input_devices = {}
-gpio_bit_input_devices["master_valve_set_switch"]   =  {"type":"CLICK", "remote":"satellite_1","input_bit":"X002", "latch_enable":True ,"latch_high":True }
-gpio_bit_input_devices["master_valve_reset_switch"] =  {"type":"CLICK", "remote":"satellite_1","input_bit":"X003", "latch_enable":True,"latch_high":True } 
+gpio_bit_input_devices["main_valve_set_switch"]   =  {"type":"CLICK", "remote":"satellite_1","input_bit":"X002", "latch_enable":True ,"latch_high":True }
+gpio_bit_input_devices["main_valve_reset_switch"] =  {"type":"CLICK", "remote":"satellite_1","input_bit":"X003", "latch_enable":True,"latch_high":True } 
 
-master_switch_keys = [ "master_valve_set_switch" ]
-master_reset_keys  = [ "master_valve_reset_switch"]
+main_switch_keys = [ "main_valve_set_switch" ]
+main_reset_keys  = [ "main_valve_reset_switch"]
 
 analog_devices = {}
 analog_devices["plc_current"]    = { "type":"CLICK", "remote":"satellite_1", "read_register":"DF1", "conversion_factor":1.0 }

--- a/__backup__/data_management/remote_devices.py
+++ b/__backup__/data_management/remote_devices.py
@@ -10,17 +10,17 @@ irrigation_io["satellite_2"] =  {  "type":"CLICK" ,"pins_number":22, "unknown":"
 irrigation_io["satellite_3"] =  {  "type":"CLICK" ,"pins_number":22, "unknown":"C201", "clear_duration_counters":"C2","duration_counter":"DS2" }
 
 
-master_valve_list = []
-master_valve_list.append( { "type":"CLICK", "remote":"satellite_1","master_valve":43, "cleaning_valve":44 } )
+main_valve_list = []
+main_valve_list.append( { "type":"CLICK", "remote":"satellite_1","main_valve":43, "cleaning_valve":44 } )
 
 #
-#  debouncing is handled by slave device
+#  debouncing is handled by subordinate device
 #  latching is enabled or disabled
 #  latching consists of High or Low Latching
 #
 gpio_input_devices = {}
-gpio_input_devices["master_valve_set_switch"]   =  {"type":"CLICK", "remote":"satellite_1","input":"X002", "latch_enable":True ,"latch_high":True }
-gpio_input_devices["master_valve_reset_switch"] =  {"type":"CLICK", "remote":"satellite_1","input":"X003", "latch_enable":True,"latch_high":True } 
+gpio_input_devices["main_valve_set_switch"]   =  {"type":"CLICK", "remote":"satellite_1","input":"X002", "latch_enable":True ,"latch_high":True }
+gpio_input_devices["main_valve_reset_switch"] =  {"type":"CLICK", "remote":"satellite_1","input":"X003", "latch_enable":True,"latch_high":True } 
 
 analog_devices = {}
 analog_devices["plc_current"]    = { "type":"CLICK", "remote":"satellite_1", "read_register":"DF1", "conversion_factor":1.0 }

--- a/__backup__/flask_web/app/system_state_module.py
+++ b/__backup__/flask_web/app/system_state_module.py
@@ -132,7 +132,7 @@ class System_state_modules:
       return_data["coil_current"]           = redis_handle.get( "coil_current" )
       return_data["eto_yesterday"]          = redis_handle.get( "YESTERDAY_ETO" )
       return_data["eto_current"]            = redis_handle.get( "CURRENT_ETO" )
-      return_data["eto_master_valve"]       = redis_handle.get("MASTER_VALVE_SETUP")
+      return_data["eto_main_valve"]       = redis_handle.get("MASTER_VALVE_SETUP")
       return_data["eto_managment_flag"]     = redis_handle.get("ETO_MANAGE_FLAG")
       temp = json.dumps(return_data)
       return temp


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.